### PR TITLE
Pc hand score

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,11 @@ The objective of this project is to develop an agent to play Mahjong using Monte
 3. Allow other players to keep playing after someone wins. The game will end when three players have won or when the wall is exhausted. Wall exhaustion scoring will also be implemented. Similarly to the second iteration, the agent will aim to maximise its win.
 
 ## Run the code on DCS Machines
+
 - `python3 code/v1/metrics.py -n <number-of-games> -save <y/n> -csv <filename> -completed <number-of-completed-games-required-for-mcts>`
 
 ### Batch compute on DCS
+
 - `sbatch dcs.sbatch`
 - `sacct --format JobId,State,MaxRSS,Elapsed,CPUTime,Start,End,Reason`
 - `seff <job-id`
@@ -41,12 +43,14 @@ The objective of this project is to develop an agent to play Mahjong using Monte
 
 ## Notes
 
-**BUG:** MCTS agent mostly discarding the tile it just picked up.
-Win rate generally is very low (~6%?) so it means many of the options have the same weights. Explains the bad performance of the agent. Might make sense to pick from a narrowed down list of possible discards so more simulations are run on "better" discards? Still need to understand though if there is something that means the tile that just got picked up is more likely to be picked. 
+**BUG (14.02.2024 update: to be reviewed again if this still happens):** MCTS agent mostly discarding the tile it just picked up.
+Win rate generally is very low (~6%?) so it means many of the options have the same weights. Explains the bad performance of the agent. Might make sense to pick from a narrowed down list of possible discards so more simulations are run on "better" discards? Still need to understand though if there is something that means the tile that just got picked up is more likely to be picked.
 
-**BUG:** MCTS fails sometimes - search hits a point where not terminal node but has no children
+**BUG (14.02.2024):** Sometimes after PENG players end up with 16 tiles - adding tiles to the wrong player but why?
 
-**BUG:** Sometimes after PENG players end up with 16 tiles
+**BUG (14.02.2024):** Bug where tiles of unwanted suit is still showing in the player's hand. Not sure why this is happening. Previously thought this was because the unwanted suit was changing when mcts was initiated. Possibly this wasn't completely fixed? But could also be due to another reason? The games run without issues when it's only rule-based agents so the issue must lie in some part of the mcts implementation.
+
+- Agent is back to playing fixed number of simulations instead of number of games that have a winner.
 
 ### Runtimes
 

--- a/code/poetry.lock
+++ b/code/poetry.lock
@@ -71,63 +71,63 @@ files = [
 
 [[package]]
 name = "coverage"
-version = "7.4.0"
+version = "7.4.1"
 description = "Code coverage measurement for Python"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "coverage-7.4.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:36b0ea8ab20d6a7564e89cb6135920bc9188fb5f1f7152e94e8300b7b189441a"},
-    {file = "coverage-7.4.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:0676cd0ba581e514b7f726495ea75aba3eb20899d824636c6f59b0ed2f88c471"},
-    {file = "coverage-7.4.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d0ca5c71a5a1765a0f8f88022c52b6b8be740e512980362f7fdbb03725a0d6b9"},
-    {file = "coverage-7.4.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a7c97726520f784239f6c62506bc70e48d01ae71e9da128259d61ca5e9788516"},
-    {file = "coverage-7.4.0-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:815ac2d0f3398a14286dc2cea223a6f338109f9ecf39a71160cd1628786bc6f5"},
-    {file = "coverage-7.4.0-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:80b5ee39b7f0131ebec7968baa9b2309eddb35b8403d1869e08f024efd883566"},
-    {file = "coverage-7.4.0-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:5b2ccb7548a0b65974860a78c9ffe1173cfb5877460e5a229238d985565574ae"},
-    {file = "coverage-7.4.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:995ea5c48c4ebfd898eacb098164b3cc826ba273b3049e4a889658548e321b43"},
-    {file = "coverage-7.4.0-cp310-cp310-win32.whl", hash = "sha256:79287fd95585ed36e83182794a57a46aeae0b64ca53929d1176db56aacc83451"},
-    {file = "coverage-7.4.0-cp310-cp310-win_amd64.whl", hash = "sha256:5b14b4f8760006bfdb6e08667af7bc2d8d9bfdb648351915315ea17645347137"},
-    {file = "coverage-7.4.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:04387a4a6ecb330c1878907ce0dc04078ea72a869263e53c72a1ba5bbdf380ca"},
-    {file = "coverage-7.4.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:ea81d8f9691bb53f4fb4db603203029643caffc82bf998ab5b59ca05560f4c06"},
-    {file = "coverage-7.4.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:74775198b702868ec2d058cb92720a3c5a9177296f75bd97317c787daf711505"},
-    {file = "coverage-7.4.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:76f03940f9973bfaee8cfba70ac991825611b9aac047e5c80d499a44079ec0bc"},
-    {file = "coverage-7.4.0-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:485e9f897cf4856a65a57c7f6ea3dc0d4e6c076c87311d4bc003f82cfe199d25"},
-    {file = "coverage-7.4.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:6ae8c9d301207e6856865867d762a4b6fd379c714fcc0607a84b92ee63feff70"},
-    {file = "coverage-7.4.0-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:bf477c355274a72435ceb140dc42de0dc1e1e0bf6e97195be30487d8eaaf1a09"},
-    {file = "coverage-7.4.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:83c2dda2666fe32332f8e87481eed056c8b4d163fe18ecc690b02802d36a4d26"},
-    {file = "coverage-7.4.0-cp311-cp311-win32.whl", hash = "sha256:697d1317e5290a313ef0d369650cfee1a114abb6021fa239ca12b4849ebbd614"},
-    {file = "coverage-7.4.0-cp311-cp311-win_amd64.whl", hash = "sha256:26776ff6c711d9d835557ee453082025d871e30b3fd6c27fcef14733f67f0590"},
-    {file = "coverage-7.4.0-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:13eaf476ec3e883fe3e5fe3707caeb88268a06284484a3daf8250259ef1ba143"},
-    {file = "coverage-7.4.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:846f52f46e212affb5bcf131c952fb4075b55aae6b61adc9856222df89cbe3e2"},
-    {file = "coverage-7.4.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:26f66da8695719ccf90e794ed567a1549bb2644a706b41e9f6eae6816b398c4a"},
-    {file = "coverage-7.4.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:164fdcc3246c69a6526a59b744b62e303039a81e42cfbbdc171c91a8cc2f9446"},
-    {file = "coverage-7.4.0-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:316543f71025a6565677d84bc4df2114e9b6a615aa39fb165d697dba06a54af9"},
-    {file = "coverage-7.4.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:bb1de682da0b824411e00a0d4da5a784ec6496b6850fdf8c865c1d68c0e318dd"},
-    {file = "coverage-7.4.0-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:0e8d06778e8fbffccfe96331a3946237f87b1e1d359d7fbe8b06b96c95a5407a"},
-    {file = "coverage-7.4.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:a56de34db7b7ff77056a37aedded01b2b98b508227d2d0979d373a9b5d353daa"},
-    {file = "coverage-7.4.0-cp312-cp312-win32.whl", hash = "sha256:51456e6fa099a8d9d91497202d9563a320513fcf59f33991b0661a4a6f2ad450"},
-    {file = "coverage-7.4.0-cp312-cp312-win_amd64.whl", hash = "sha256:cd3c1e4cb2ff0083758f09be0f77402e1bdf704adb7f89108007300a6da587d0"},
-    {file = "coverage-7.4.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:e9d1bf53c4c8de58d22e0e956a79a5b37f754ed1ffdbf1a260d9dcfa2d8a325e"},
-    {file = "coverage-7.4.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:109f5985182b6b81fe33323ab4707011875198c41964f014579cf82cebf2bb85"},
-    {file = "coverage-7.4.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3cc9d4bc55de8003663ec94c2f215d12d42ceea128da8f0f4036235a119c88ac"},
-    {file = "coverage-7.4.0-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:cc6d65b21c219ec2072c1293c505cf36e4e913a3f936d80028993dd73c7906b1"},
-    {file = "coverage-7.4.0-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5a10a4920def78bbfff4eff8a05c51be03e42f1c3735be42d851f199144897ba"},
-    {file = "coverage-7.4.0-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:b8e99f06160602bc64da35158bb76c73522a4010f0649be44a4e167ff8555952"},
-    {file = "coverage-7.4.0-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:7d360587e64d006402b7116623cebf9d48893329ef035278969fa3bbf75b697e"},
-    {file = "coverage-7.4.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:29f3abe810930311c0b5d1a7140f6395369c3db1be68345638c33eec07535105"},
-    {file = "coverage-7.4.0-cp38-cp38-win32.whl", hash = "sha256:5040148f4ec43644702e7b16ca864c5314ccb8ee0751ef617d49aa0e2d6bf4f2"},
-    {file = "coverage-7.4.0-cp38-cp38-win_amd64.whl", hash = "sha256:9864463c1c2f9cb3b5db2cf1ff475eed2f0b4285c2aaf4d357b69959941aa555"},
-    {file = "coverage-7.4.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:936d38794044b26c99d3dd004d8af0035ac535b92090f7f2bb5aa9c8e2f5cd42"},
-    {file = "coverage-7.4.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:799c8f873794a08cdf216aa5d0531c6a3747793b70c53f70e98259720a6fe2d7"},
-    {file = "coverage-7.4.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e7defbb9737274023e2d7af02cac77043c86ce88a907c58f42b580a97d5bcca9"},
-    {file = "coverage-7.4.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a1526d265743fb49363974b7aa8d5899ff64ee07df47dd8d3e37dcc0818f09ed"},
-    {file = "coverage-7.4.0-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bf635a52fc1ea401baf88843ae8708591aa4adff875e5c23220de43b1ccf575c"},
-    {file = "coverage-7.4.0-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:756ded44f47f330666843b5781be126ab57bb57c22adbb07d83f6b519783b870"},
-    {file = "coverage-7.4.0-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:0eb3c2f32dabe3a4aaf6441dde94f35687224dfd7eb2a7f47f3fd9428e421058"},
-    {file = "coverage-7.4.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:bfd5db349d15c08311702611f3dccbef4b4e2ec148fcc636cf8739519b4a5c0f"},
-    {file = "coverage-7.4.0-cp39-cp39-win32.whl", hash = "sha256:53d7d9158ee03956e0eadac38dfa1ec8068431ef8058fe6447043db1fb40d932"},
-    {file = "coverage-7.4.0-cp39-cp39-win_amd64.whl", hash = "sha256:cfd2a8b6b0d8e66e944d47cdec2f47c48fef2ba2f2dff5a9a75757f64172857e"},
-    {file = "coverage-7.4.0-pp38.pp39.pp310-none-any.whl", hash = "sha256:c530833afc4707fe48524a44844493f36d8727f04dcce91fb978c414a8556cc6"},
-    {file = "coverage-7.4.0.tar.gz", hash = "sha256:707c0f58cb1712b8809ece32b68996ee1e609f71bd14615bd8f87a1293cb610e"},
+    {file = "coverage-7.4.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:077d366e724f24fc02dbfe9d946534357fda71af9764ff99d73c3c596001bbd7"},
+    {file = "coverage-7.4.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:0193657651f5399d433c92f8ae264aff31fc1d066deee4b831549526433f3f61"},
+    {file = "coverage-7.4.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d17bbc946f52ca67adf72a5ee783cd7cd3477f8f8796f59b4974a9b59cacc9ee"},
+    {file = "coverage-7.4.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a3277f5fa7483c927fe3a7b017b39351610265308f5267ac6d4c2b64cc1d8d25"},
+    {file = "coverage-7.4.1-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6dceb61d40cbfcf45f51e59933c784a50846dc03211054bd76b421a713dcdf19"},
+    {file = "coverage-7.4.1-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:6008adeca04a445ea6ef31b2cbaf1d01d02986047606f7da266629afee982630"},
+    {file = "coverage-7.4.1-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:c61f66d93d712f6e03369b6a7769233bfda880b12f417eefdd4f16d1deb2fc4c"},
+    {file = "coverage-7.4.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:b9bb62fac84d5f2ff523304e59e5c439955fb3b7f44e3d7b2085184db74d733b"},
+    {file = "coverage-7.4.1-cp310-cp310-win32.whl", hash = "sha256:f86f368e1c7ce897bf2457b9eb61169a44e2ef797099fb5728482b8d69f3f016"},
+    {file = "coverage-7.4.1-cp310-cp310-win_amd64.whl", hash = "sha256:869b5046d41abfea3e381dd143407b0d29b8282a904a19cb908fa24d090cc018"},
+    {file = "coverage-7.4.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:b8ffb498a83d7e0305968289441914154fb0ef5d8b3157df02a90c6695978295"},
+    {file = "coverage-7.4.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:3cacfaefe6089d477264001f90f55b7881ba615953414999c46cc9713ff93c8c"},
+    {file = "coverage-7.4.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5d6850e6e36e332d5511a48a251790ddc545e16e8beaf046c03985c69ccb2676"},
+    {file = "coverage-7.4.1-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:18e961aa13b6d47f758cc5879383d27b5b3f3dcd9ce8cdbfdc2571fe86feb4dd"},
+    {file = "coverage-7.4.1-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dfd1e1b9f0898817babf840b77ce9fe655ecbe8b1b327983df485b30df8cc011"},
+    {file = "coverage-7.4.1-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:6b00e21f86598b6330f0019b40fb397e705135040dbedc2ca9a93c7441178e74"},
+    {file = "coverage-7.4.1-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:536d609c6963c50055bab766d9951b6c394759190d03311f3e9fcf194ca909e1"},
+    {file = "coverage-7.4.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:7ac8f8eb153724f84885a1374999b7e45734bf93a87d8df1e7ce2146860edef6"},
+    {file = "coverage-7.4.1-cp311-cp311-win32.whl", hash = "sha256:f3771b23bb3675a06f5d885c3630b1d01ea6cac9e84a01aaf5508706dba546c5"},
+    {file = "coverage-7.4.1-cp311-cp311-win_amd64.whl", hash = "sha256:9d2f9d4cc2a53b38cabc2d6d80f7f9b7e3da26b2f53d48f05876fef7956b6968"},
+    {file = "coverage-7.4.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:f68ef3660677e6624c8cace943e4765545f8191313a07288a53d3da188bd8581"},
+    {file = "coverage-7.4.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:23b27b8a698e749b61809fb637eb98ebf0e505710ec46a8aa6f1be7dc0dc43a6"},
+    {file = "coverage-7.4.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3e3424c554391dc9ef4a92ad28665756566a28fecf47308f91841f6c49288e66"},
+    {file = "coverage-7.4.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e0860a348bf7004c812c8368d1fc7f77fe8e4c095d661a579196a9533778e156"},
+    {file = "coverage-7.4.1-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fe558371c1bdf3b8fa03e097c523fb9645b8730399c14fe7721ee9c9e2a545d3"},
+    {file = "coverage-7.4.1-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:3468cc8720402af37b6c6e7e2a9cdb9f6c16c728638a2ebc768ba1ef6f26c3a1"},
+    {file = "coverage-7.4.1-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:02f2edb575d62172aa28fe00efe821ae31f25dc3d589055b3fb64d51e52e4ab1"},
+    {file = "coverage-7.4.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:ca6e61dc52f601d1d224526360cdeab0d0712ec104a2ce6cc5ccef6ed9a233bc"},
+    {file = "coverage-7.4.1-cp312-cp312-win32.whl", hash = "sha256:ca7b26a5e456a843b9b6683eada193fc1f65c761b3a473941efe5a291f604c74"},
+    {file = "coverage-7.4.1-cp312-cp312-win_amd64.whl", hash = "sha256:85ccc5fa54c2ed64bd91ed3b4a627b9cce04646a659512a051fa82a92c04a448"},
+    {file = "coverage-7.4.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:8bdb0285a0202888d19ec6b6d23d5990410decb932b709f2b0dfe216d031d218"},
+    {file = "coverage-7.4.1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:918440dea04521f499721c039863ef95433314b1db00ff826a02580c1f503e45"},
+    {file = "coverage-7.4.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:379d4c7abad5afbe9d88cc31ea8ca262296480a86af945b08214eb1a556a3e4d"},
+    {file = "coverage-7.4.1-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b094116f0b6155e36a304ff912f89bbb5067157aff5f94060ff20bbabdc8da06"},
+    {file = "coverage-7.4.1-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f2f5968608b1fe2a1d00d01ad1017ee27efd99b3437e08b83ded9b7af3f6f766"},
+    {file = "coverage-7.4.1-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:10e88e7f41e6197ea0429ae18f21ff521d4f4490aa33048f6c6f94c6045a6a75"},
+    {file = "coverage-7.4.1-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:a4a3907011d39dbc3e37bdc5df0a8c93853c369039b59efa33a7b6669de04c60"},
+    {file = "coverage-7.4.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:6d224f0c4c9c98290a6990259073f496fcec1b5cc613eecbd22786d398ded3ad"},
+    {file = "coverage-7.4.1-cp38-cp38-win32.whl", hash = "sha256:23f5881362dcb0e1a92b84b3c2809bdc90db892332daab81ad8f642d8ed55042"},
+    {file = "coverage-7.4.1-cp38-cp38-win_amd64.whl", hash = "sha256:a07f61fc452c43cd5328b392e52555f7d1952400a1ad09086c4a8addccbd138d"},
+    {file = "coverage-7.4.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:8e738a492b6221f8dcf281b67129510835461132b03024830ac0e554311a5c54"},
+    {file = "coverage-7.4.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:46342fed0fff72efcda77040b14728049200cbba1279e0bf1188f1f2078c1d70"},
+    {file = "coverage-7.4.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9641e21670c68c7e57d2053ddf6c443e4f0a6e18e547e86af3fad0795414a628"},
+    {file = "coverage-7.4.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:aeb2c2688ed93b027eb0d26aa188ada34acb22dceea256d76390eea135083950"},
+    {file = "coverage-7.4.1-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d12c923757de24e4e2110cf8832d83a886a4cf215c6e61ed506006872b43a6d1"},
+    {file = "coverage-7.4.1-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:0491275c3b9971cdbd28a4595c2cb5838f08036bca31765bad5e17edf900b2c7"},
+    {file = "coverage-7.4.1-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:8dfc5e195bbef80aabd81596ef52a1277ee7143fe419efc3c4d8ba2754671756"},
+    {file = "coverage-7.4.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:1a78b656a4d12b0490ca72651fe4d9f5e07e3c6461063a9b6265ee45eb2bdd35"},
+    {file = "coverage-7.4.1-cp39-cp39-win32.whl", hash = "sha256:f90515974b39f4dea2f27c0959688621b46d96d5a626cf9c53dbc653a895c05c"},
+    {file = "coverage-7.4.1-cp39-cp39-win_amd64.whl", hash = "sha256:64e723ca82a84053dd7bfcc986bdb34af8d9da83c521c19d6b472bc6880e191a"},
+    {file = "coverage-7.4.1-pp38.pp39.pp310-none-any.whl", hash = "sha256:32a8d985462e37cfdab611a6f95b09d7c091d07668fdc26e47a725ee575fe166"},
+    {file = "coverage-7.4.1.tar.gz", hash = "sha256:1ed4b95480952b1a26d863e546fa5094564aa0065e1e5f0d4d0041f293251d04"},
 ]
 
 [package.extras]
@@ -235,47 +235,47 @@ numpy = ">=1.22,<1.27"
 
 [[package]]
 name = "numpy"
-version = "1.26.3"
+version = "1.26.4"
 description = "Fundamental package for array computing in Python"
 optional = false
 python-versions = ">=3.9"
 files = [
-    {file = "numpy-1.26.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:806dd64230dbbfaca8a27faa64e2f414bf1c6622ab78cc4264f7f5f028fee3bf"},
-    {file = "numpy-1.26.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:02f98011ba4ab17f46f80f7f8f1c291ee7d855fcef0a5a98db80767a468c85cd"},
-    {file = "numpy-1.26.3-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6d45b3ec2faed4baca41c76617fcdcfa4f684ff7a151ce6fc78ad3b6e85af0a6"},
-    {file = "numpy-1.26.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bdd2b45bf079d9ad90377048e2747a0c82351989a2165821f0c96831b4a2a54b"},
-    {file = "numpy-1.26.3-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:211ddd1e94817ed2d175b60b6374120244a4dd2287f4ece45d49228b4d529178"},
-    {file = "numpy-1.26.3-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:b1240f767f69d7c4c8a29adde2310b871153df9b26b5cb2b54a561ac85146485"},
-    {file = "numpy-1.26.3-cp310-cp310-win32.whl", hash = "sha256:21a9484e75ad018974a2fdaa216524d64ed4212e418e0a551a2d83403b0531d3"},
-    {file = "numpy-1.26.3-cp310-cp310-win_amd64.whl", hash = "sha256:9e1591f6ae98bcfac2a4bbf9221c0b92ab49762228f38287f6eeb5f3f55905ce"},
-    {file = "numpy-1.26.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:b831295e5472954104ecb46cd98c08b98b49c69fdb7040483aff799a755a7374"},
-    {file = "numpy-1.26.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:9e87562b91f68dd8b1c39149d0323b42e0082db7ddb8e934ab4c292094d575d6"},
-    {file = "numpy-1.26.3-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8c66d6fec467e8c0f975818c1796d25c53521124b7cfb760114be0abad53a0a2"},
-    {file = "numpy-1.26.3-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f25e2811a9c932e43943a2615e65fc487a0b6b49218899e62e426e7f0a57eeda"},
-    {file = "numpy-1.26.3-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:af36e0aa45e25c9f57bf684b1175e59ea05d9a7d3e8e87b7ae1a1da246f2767e"},
-    {file = "numpy-1.26.3-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:51c7f1b344f302067b02e0f5b5d2daa9ed4a721cf49f070280ac202738ea7f00"},
-    {file = "numpy-1.26.3-cp311-cp311-win32.whl", hash = "sha256:7ca4f24341df071877849eb2034948459ce3a07915c2734f1abb4018d9c49d7b"},
-    {file = "numpy-1.26.3-cp311-cp311-win_amd64.whl", hash = "sha256:39763aee6dfdd4878032361b30b2b12593fb445ddb66bbac802e2113eb8a6ac4"},
-    {file = "numpy-1.26.3-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:a7081fd19a6d573e1a05e600c82a1c421011db7935ed0d5c483e9dd96b99cf13"},
-    {file = "numpy-1.26.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:12c70ac274b32bc00c7f61b515126c9205323703abb99cd41836e8125ea0043e"},
-    {file = "numpy-1.26.3-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7f784e13e598e9594750b2ef6729bcd5a47f6cfe4a12cca13def35e06d8163e3"},
-    {file = "numpy-1.26.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5f24750ef94d56ce6e33e4019a8a4d68cfdb1ef661a52cdaee628a56d2437419"},
-    {file = "numpy-1.26.3-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:77810ef29e0fb1d289d225cabb9ee6cf4d11978a00bb99f7f8ec2132a84e0166"},
-    {file = "numpy-1.26.3-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8ed07a90f5450d99dad60d3799f9c03c6566709bd53b497eb9ccad9a55867f36"},
-    {file = "numpy-1.26.3-cp312-cp312-win32.whl", hash = "sha256:f73497e8c38295aaa4741bdfa4fda1a5aedda5473074369eca10626835445511"},
-    {file = "numpy-1.26.3-cp312-cp312-win_amd64.whl", hash = "sha256:da4b0c6c699a0ad73c810736303f7fbae483bcb012e38d7eb06a5e3b432c981b"},
-    {file = "numpy-1.26.3-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:1666f634cb3c80ccbd77ec97bc17337718f56d6658acf5d3b906ca03e90ce87f"},
-    {file = "numpy-1.26.3-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:18c3319a7d39b2c6a9e3bb75aab2304ab79a811ac0168a671a62e6346c29b03f"},
-    {file = "numpy-1.26.3-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0b7e807d6888da0db6e7e75838444d62495e2b588b99e90dd80c3459594e857b"},
-    {file = "numpy-1.26.3-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b4d362e17bcb0011738c2d83e0a65ea8ce627057b2fdda37678f4374a382a137"},
-    {file = "numpy-1.26.3-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:b8c275f0ae90069496068c714387b4a0eba5d531aace269559ff2b43655edd58"},
-    {file = "numpy-1.26.3-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:cc0743f0302b94f397a4a65a660d4cd24267439eb16493fb3caad2e4389bccbb"},
-    {file = "numpy-1.26.3-cp39-cp39-win32.whl", hash = "sha256:9bc6d1a7f8cedd519c4b7b1156d98e051b726bf160715b769106661d567b3f03"},
-    {file = "numpy-1.26.3-cp39-cp39-win_amd64.whl", hash = "sha256:867e3644e208c8922a3be26fc6bbf112a035f50f0a86497f98f228c50c607bb2"},
-    {file = "numpy-1.26.3-pp39-pypy39_pp73-macosx_10_9_x86_64.whl", hash = "sha256:3c67423b3703f8fbd90f5adaa37f85b5794d3366948efe9a5190a5f3a83fc34e"},
-    {file = "numpy-1.26.3-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:46f47ee566d98849323f01b349d58f2557f02167ee301e5e28809a8c0e27a2d0"},
-    {file = "numpy-1.26.3-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:a8474703bffc65ca15853d5fd4d06b18138ae90c17c8d12169968e998e448bb5"},
-    {file = "numpy-1.26.3.tar.gz", hash = "sha256:697df43e2b6310ecc9d95f05d5ef20eacc09c7c4ecc9da3f235d39e71b7da1e4"},
+    {file = "numpy-1.26.4-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:9ff0f4f29c51e2803569d7a51c2304de5554655a60c5d776e35b4a41413830d0"},
+    {file = "numpy-1.26.4-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:2e4ee3380d6de9c9ec04745830fd9e2eccb3e6cf790d39d7b98ffd19b0dd754a"},
+    {file = "numpy-1.26.4-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d209d8969599b27ad20994c8e41936ee0964e6da07478d6c35016bc386b66ad4"},
+    {file = "numpy-1.26.4-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ffa75af20b44f8dba823498024771d5ac50620e6915abac414251bd971b4529f"},
+    {file = "numpy-1.26.4-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:62b8e4b1e28009ef2846b4c7852046736bab361f7aeadeb6a5b89ebec3c7055a"},
+    {file = "numpy-1.26.4-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:a4abb4f9001ad2858e7ac189089c42178fcce737e4169dc61321660f1a96c7d2"},
+    {file = "numpy-1.26.4-cp310-cp310-win32.whl", hash = "sha256:bfe25acf8b437eb2a8b2d49d443800a5f18508cd811fea3181723922a8a82b07"},
+    {file = "numpy-1.26.4-cp310-cp310-win_amd64.whl", hash = "sha256:b97fe8060236edf3662adfc2c633f56a08ae30560c56310562cb4f95500022d5"},
+    {file = "numpy-1.26.4-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:4c66707fabe114439db9068ee468c26bbdf909cac0fb58686a42a24de1760c71"},
+    {file = "numpy-1.26.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:edd8b5fe47dab091176d21bb6de568acdd906d1887a4584a15a9a96a1dca06ef"},
+    {file = "numpy-1.26.4-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7ab55401287bfec946ced39700c053796e7cc0e3acbef09993a9ad2adba6ca6e"},
+    {file = "numpy-1.26.4-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:666dbfb6ec68962c033a450943ded891bed2d54e6755e35e5835d63f4f6931d5"},
+    {file = "numpy-1.26.4-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:96ff0b2ad353d8f990b63294c8986f1ec3cb19d749234014f4e7eb0112ceba5a"},
+    {file = "numpy-1.26.4-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:60dedbb91afcbfdc9bc0b1f3f402804070deed7392c23eb7a7f07fa857868e8a"},
+    {file = "numpy-1.26.4-cp311-cp311-win32.whl", hash = "sha256:1af303d6b2210eb850fcf03064d364652b7120803a0b872f5211f5234b399f20"},
+    {file = "numpy-1.26.4-cp311-cp311-win_amd64.whl", hash = "sha256:cd25bcecc4974d09257ffcd1f098ee778f7834c3ad767fe5db785be9a4aa9cb2"},
+    {file = "numpy-1.26.4-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:b3ce300f3644fb06443ee2222c2201dd3a89ea6040541412b8fa189341847218"},
+    {file = "numpy-1.26.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:03a8c78d01d9781b28a6989f6fa1bb2c4f2d51201cf99d3dd875df6fbd96b23b"},
+    {file = "numpy-1.26.4-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9fad7dcb1aac3c7f0584a5a8133e3a43eeb2fe127f47e3632d43d677c66c102b"},
+    {file = "numpy-1.26.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:675d61ffbfa78604709862923189bad94014bef562cc35cf61d3a07bba02a7ed"},
+    {file = "numpy-1.26.4-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:ab47dbe5cc8210f55aa58e4805fe224dac469cde56b9f731a4c098b91917159a"},
+    {file = "numpy-1.26.4-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:1dda2e7b4ec9dd512f84935c5f126c8bd8b9f2fc001e9f54af255e8c5f16b0e0"},
+    {file = "numpy-1.26.4-cp312-cp312-win32.whl", hash = "sha256:50193e430acfc1346175fcbdaa28ffec49947a06918b7b92130744e81e640110"},
+    {file = "numpy-1.26.4-cp312-cp312-win_amd64.whl", hash = "sha256:08beddf13648eb95f8d867350f6a018a4be2e5ad54c8d8caed89ebca558b2818"},
+    {file = "numpy-1.26.4-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:7349ab0fa0c429c82442a27a9673fc802ffdb7c7775fad780226cb234965e53c"},
+    {file = "numpy-1.26.4-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:52b8b60467cd7dd1e9ed082188b4e6bb35aa5cdd01777621a1658910745b90be"},
+    {file = "numpy-1.26.4-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d5241e0a80d808d70546c697135da2c613f30e28251ff8307eb72ba696945764"},
+    {file = "numpy-1.26.4-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f870204a840a60da0b12273ef34f7051e98c3b5961b61b0c2c1be6dfd64fbcd3"},
+    {file = "numpy-1.26.4-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:679b0076f67ecc0138fd2ede3a8fd196dddc2ad3254069bcb9faf9a79b1cebcd"},
+    {file = "numpy-1.26.4-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:47711010ad8555514b434df65f7d7b076bb8261df1ca9bb78f53d3b2db02e95c"},
+    {file = "numpy-1.26.4-cp39-cp39-win32.whl", hash = "sha256:a354325ee03388678242a4d7ebcd08b5c727033fcff3b2f536aea978e15ee9e6"},
+    {file = "numpy-1.26.4-cp39-cp39-win_amd64.whl", hash = "sha256:3373d5d70a5fe74a2c1bb6d2cfd9609ecf686d47a2d7b1d37a8f3b6bf6003aea"},
+    {file = "numpy-1.26.4-pp39-pypy39_pp73-macosx_10_9_x86_64.whl", hash = "sha256:afedb719a9dcfc7eaf2287b839d8198e06dcd4cb5d276a3df279231138e83d30"},
+    {file = "numpy-1.26.4-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:95a7476c59002f2f6c590b9b7b998306fba6a5aa646b1e22ddfeaf8f78c3a29c"},
+    {file = "numpy-1.26.4-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:7e50d0a0cc3189f9cb0aeb3a6a6af18c16f59f004b866cd2be1c14b36134a4a0"},
+    {file = "numpy-1.26.4.tar.gz", hash = "sha256:2a02aba9ed12e4ac4eb3ea9421c420301a0c6460d9830d74a9df87efa4912010"},
 ]
 
 [[package]]
@@ -370,18 +370,18 @@ files = [
 
 [[package]]
 name = "platformdirs"
-version = "4.1.0"
+version = "4.2.0"
 description = "A small Python package for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "platformdirs-4.1.0-py3-none-any.whl", hash = "sha256:11c8f37bcca40db96d8144522d925583bdb7a31f7b0e37e3ed4318400a8e2380"},
-    {file = "platformdirs-4.1.0.tar.gz", hash = "sha256:906d548203468492d432bcb294d4bc2fff751bf84971fbb2c10918cc206ee420"},
+    {file = "platformdirs-4.2.0-py3-none-any.whl", hash = "sha256:0614df2a2f37e1a662acbd8e2b25b92ccf8632929bc6d43467e17fe89c75e068"},
+    {file = "platformdirs-4.2.0.tar.gz", hash = "sha256:ef0cc731df711022c174543cb70a9b5bd22e5a9337c8624ef2c2ceb8ddad8768"},
 ]
 
 [package.extras]
-docs = ["furo (>=2023.7.26)", "proselint (>=0.13)", "sphinx (>=7.1.1)", "sphinx-autodoc-typehints (>=1.24)"]
-test = ["appdirs (==1.4.4)", "covdefaults (>=2.3)", "pytest (>=7.4)", "pytest-cov (>=4.1)", "pytest-mock (>=3.11.1)"]
+docs = ["furo (>=2023.9.10)", "proselint (>=0.13)", "sphinx (>=7.2.6)", "sphinx-autodoc-typehints (>=1.25.2)"]
+test = ["appdirs (==1.4.4)", "covdefaults (>=2.3)", "pytest (>=7.4.3)", "pytest-cov (>=4.1)", "pytest-mock (>=3.12)"]
 
 [[package]]
 name = "pluggy"
@@ -434,13 +434,13 @@ six = ">=1.5"
 
 [[package]]
 name = "pytz"
-version = "2023.3.post1"
+version = "2024.1"
 description = "World timezone definitions, modern and historical"
 optional = false
 python-versions = "*"
 files = [
-    {file = "pytz-2023.3.post1-py2.py3-none-any.whl", hash = "sha256:ce42d816b81b68506614c11e8937d3aa9e41007ceb50bfdcb0749b921bf646c7"},
-    {file = "pytz-2023.3.post1.tar.gz", hash = "sha256:7b4fddbeb94a1eba4b557da24f19fdf9db575192544270a9101d8509f9f43d7b"},
+    {file = "pytz-2024.1-py2.py3-none-any.whl", hash = "sha256:328171f4e3623139da4983451950b28e95ac706e13f3f2630a879749e7a8b319"},
+    {file = "pytz-2024.1.tar.gz", hash = "sha256:2a29735ea9c18baf14b448846bde5a48030ed267578472d8955cd0e7443a9812"},
 ]
 
 [[package]]
@@ -456,13 +456,13 @@ files = [
 
 [[package]]
 name = "tzdata"
-version = "2023.4"
+version = "2024.1"
 description = "Provider of IANA time zone data"
 optional = false
 python-versions = ">=2"
 files = [
-    {file = "tzdata-2023.4-py2.py3-none-any.whl", hash = "sha256:aa3ace4329eeacda5b7beb7ea08ece826c28d761cda36e747cfbf97996d39bf3"},
-    {file = "tzdata-2023.4.tar.gz", hash = "sha256:dd54c94f294765522c77399649b4fefd95522479a664a0cec87f41bebc6148c9"},
+    {file = "tzdata-2024.1-py2.py3-none-any.whl", hash = "sha256:9068bc196136463f5245e51efda838afa15aaeca9903f49050dfa2679db4d252"},
+    {file = "tzdata-2024.1.tar.gz", hash = "sha256:2674120f8d891909751c38abcdfd386ac0a5a1127954fbc332af6b5ceae07efd"},
 ]
 
 [metadata]

--- a/code/v1/base_game.py
+++ b/code/v1/base_game.py
@@ -1,9 +1,9 @@
-from tiles import *
+from v1.tiles import *
 from datetime import datetime
 
-from players import *
+from v1.players import *
 import pandas as pd
-from game_state import *
+from v1.game_state import *
 
 
 # fixed values
@@ -85,17 +85,17 @@ def main(player_types, completed_games, print_output=False):
 
     state = GameState(deck, all_players)
 
-    # print initial game state
-    state.print()
+    # # print initial game state
+    # state.print()
 
     # gameplay
     while not state.ended():
         state = state.next_game_state()
         for p in all_players:
-            p.all_tiles().hand_score()
+            p.all_tiles().hand_score(p.unwanted_suit)
 
-    # end of game output
-    state.print()
+    # # end of game output
+    # state.print()
     return end_of_game_output(state, print_output)
 
 
@@ -104,6 +104,7 @@ def review():
     agents = ["MCTS", "SEMIRANDOM", "SEMIRANDOM", "SEMIRANDOM"]
     main(agents, True)
     print(f"Game took {datetime.now() - startTime} to run.")
+
 
 if __name__ == "__main__":
     main()

--- a/code/v1/base_game.py
+++ b/code/v1/base_game.py
@@ -91,6 +91,8 @@ def main(player_types, completed_games, print_output=False):
     # gameplay
     while not state.ended():
         state = state.next_game_state()
+        for p in all_players:
+            p.all_tiles().hand_score()
 
     # end of game output
     state.print()

--- a/code/v1/game_state.py
+++ b/code/v1/game_state.py
@@ -58,10 +58,17 @@ class GameState:
     def game_result(self, maximising_player):
         if self.any_wins(DUMMY_TILE) == maximising_player:
             return 1
-        elif self.any_wins(DUMMY_TILE) == -1:
-            return 0
-        else:
+        elif self.any_wins(DUMMY_TILE) != -1:
             return -1
+        else:
+            # return 0
+            scores = [p.all_tiles().hand_score() for p in self._players]
+            max_player_score = scores.pop(maximising_player)
+            # option 1: take the highest of other player's score
+            other_score = max(scores)
+            # # option 2: take the average of the other player's score
+            # other_score = sum(scores) / len(scores)
+            return max_player_score - other_score
 
     def ended(self):
         if self.deck.size() == 0:

--- a/code/v1/game_state.py
+++ b/code/v1/game_state.py
@@ -1,6 +1,7 @@
-from tiles import *
+from v1.tiles import *
 from copy import deepcopy
-from players import SemiRandomAgent
+from v1.players import SemiRandomAgent
+import pdb
 
 
 class GameState:
@@ -61,11 +62,11 @@ class GameState:
         elif self.any_wins(DUMMY_TILE) != -1:
             return -1
         else:
-            # return 0
-            scores = [p.all_tiles().hand_score() for p in self._players]
+            scores = [p.all_tiles().hand_score(p.unwanted_suit) for p in self._players]
             max_player_score = scores.pop(maximising_player)
             # option 1: take the highest of other player's score
             other_score = max(scores)
+            # print(max_player_score - other_score)
             # # option 2: take the average of the other player's score
             # other_score = sum(scores) / len(scores)
             return max_player_score - other_score
@@ -111,7 +112,9 @@ class GameState:
                     newly_assigned_tiles.add(hidden_tiles.remove_random_tile())
                 players.append(
                     SemiRandomAgent(
-                        newly_assigned_tiles, self._players[i].displayed_tiles
+                        newly_assigned_tiles,
+                        self._players[i].displayed_tiles,
+                        self._players[i].unwanted_suit,
                     )
                 )
 
@@ -196,7 +199,10 @@ class GameState:
         # return new game state
         return GameState(
             deck,
-            players_copy,
+            players_copy,  # why does this instead of players mean that there isn't a problem of the peng being added to the wrong player?
+            # does it mean actually it's still adding peng to the wrong player?
+            # and i'm not seeing it because i'm doing this step?
+            # is that why players end up with unwanted suit in their displayed/locked tiles?
             discarded_tiles,
             last_discarded,
             current_player_number,

--- a/code/v1/mcts.py
+++ b/code/v1/mcts.py
@@ -10,9 +10,10 @@ class MonteCarloTreeSearchNode:
         self.parent_action = parent_action
         self.children = []
         self._number_of_visits = 0
-        self._results = defaultdict(int)
-        self._results[1] = 0
-        self._results[-1] = 0
+        self._results = 0
+        # self._results = defaultdict(int)
+        # self._results[1] = 0
+        # self._results[-1] = 0
         self._untried_actions = self.untried_actions()
         self.maximising_player = state._current_player_number
         return
@@ -23,10 +24,11 @@ class MonteCarloTreeSearchNode:
         return self._untried_actions
 
     def q(self):
-        wins = self._results[1]
-        loses = self._results[-1]
-        q_value = wins - loses
-        return q_value
+        # wins = self._results[1]
+        # loses = self._results[-1]
+        # q_value = wins - loses
+        # return q_value
+        return self._results
 
     def n(self):
         return self._number_of_visits
@@ -61,7 +63,8 @@ class MonteCarloTreeSearchNode:
         # Check the result being backpropagated and the current node's visit count and results
         # Variables to check: result, self._number_of_visits, self._results
         self._number_of_visits += 1.0
-        self._results[result] += 1.0
+        # self._results[result] += 1.0
+        self._results += result
         
         if self.parent is not None:
             self.parent.backpropagate(result)
@@ -112,10 +115,10 @@ class MonteCarloTreeSearchNode:
         return current_node
 
     def best_action(self):
-        # for i in range(self.simulation_no):
-        limit_count = self.completed_games * 10
-        i = 0
-        while self._results[1] + self._results[-1] < self.completed_games and i < limit_count:
+        for i in range(self.completed_games): # simulation number
+        # limit_count = self.completed_games * 10
+        # i = 0
+        # while self._results[1] + self._results[-1] < self.completed_games and i < limit_count:
             v = self._tree_policy()
             reward = v.rollout()
             v.backpropagate(reward)

--- a/code/v1/mcts.py
+++ b/code/v1/mcts.py
@@ -2,6 +2,7 @@ import numpy as np
 from collections import defaultdict
 import pdb
 
+
 class MonteCarloTreeSearchNode:
     def __init__(self, state, completed_games, parent=None, parent_action=None):
         self.completed_games = completed_games
@@ -65,7 +66,7 @@ class MonteCarloTreeSearchNode:
         self._number_of_visits += 1.0
         # self._results[result] += 1.0
         self._results += result
-        
+
         if self.parent is not None:
             self.parent.backpropagate(result)
 
@@ -115,18 +116,18 @@ class MonteCarloTreeSearchNode:
         return current_node
 
     def best_action(self):
-        for i in range(self.completed_games): # simulation number
-        # limit_count = self.completed_games * 10
-        # i = 0
-        # while self._results[1] + self._results[-1] < self.completed_games and i < limit_count:
+        for i in range(self.completed_games):  # simulation number
+            # limit_count = self.completed_games * 10
+            # i = 0
+            # while self._results[1] + self._results[-1] < self.completed_games and i < limit_count:
             v = self._tree_policy()
             reward = v.rollout()
             v.backpropagate(reward)
             i += 1
 
         # pdb.set_trace()
-        print(self._number_of_visits, self._results)
-        return self.best_child(c_param=0.0) # value can (and should) be adjusted
+        # print(self._number_of_visits, self._results)
+        return self.best_child(c_param=0.0)  # value can (and should) be adjusted
 
     def get_legal_actions(self):
         actions = []

--- a/code/v1/metrics.py
+++ b/code/v1/metrics.py
@@ -1,17 +1,17 @@
 import pandas as pd
 import numpy as np
 import os
-from base_game import main as base_game
+from v1.base_game import main as base_game
 import math
 from datetime import datetime
 import itertools
 import argparse
 import traceback
-    
+
 
 wins = {}
 PLAYER_MAPPING = {0: "player0", 1: "player1", 2: "player2", 3: "player3"}
-# POSSIBLE_AGENTS = ["RANDOM", "SEMIRANDOM"] # "MCTS"]
+# POSSIBLE_AGENTS = ["RANDOM", "SEMIRANDOM"]  # "MCTS"]
 POSSIBLE_AGENTS = ["MCTS"]
 
 
@@ -93,7 +93,7 @@ def main():
     # open files
 
     args = parse_arguments()
-    game_hist = pd.read_csv(f"{os.getcwd()}/code/v1/{args.csv}.csv")
+    game_hist = pd.read_csv(f"{os.getcwd()}/v1/{args.csv}.csv")
 
     n = args.n
     save = args.save == "y"
@@ -113,7 +113,7 @@ def main():
                 if save:
                     # save data to files
                     game_hist.to_csv(
-                        os.getcwd() + "/" + f"code/v1/{args.csv}.csv", index=False
+                        os.getcwd() + "/" + f"/v1/{args.csv}.csv", index=False
                     )
             except Exception as e:
                 print(e)
@@ -140,6 +140,7 @@ def main():
             print(
                 f"{agent} win rate: {round(wins[agent][0]/wins[agent][1] * 100, 2)}% ({wins[agent][0]} of {wins[agent][1]} games played)"
             )
+
 
 if __name__ == "__main__":
     main()

--- a/code/v1/metrics.py
+++ b/code/v1/metrics.py
@@ -6,11 +6,13 @@ import math
 from datetime import datetime
 import itertools
 import argparse
+import traceback
+    
 
 wins = {}
 PLAYER_MAPPING = {0: "player0", 1: "player1", 2: "player2", 3: "player3"}
-POSSIBLE_AGENTS = ["RANDOM", "SEMIRANDOM"] # "MCTS"]
-# POSSIBLE_AGENTS = ["MCTS"]
+# POSSIBLE_AGENTS = ["RANDOM", "SEMIRANDOM"] # "MCTS"]
+POSSIBLE_AGENTS = ["MCTS"]
 
 
 def add_to_wins(row):
@@ -116,6 +118,7 @@ def main():
             except Exception as e:
                 print(e)
                 print(p)
+                traceback.print_exc()
                 failed_games += 1
                 continue
 

--- a/code/v1/players.py
+++ b/code/v1/players.py
@@ -66,7 +66,12 @@ class Player(ABC):
     def discard(self, game_state=None):
         tiles_by_suit = self.possible_discards.get_tiles_by_suit()
         if self.unwanted_suit not in tiles_by_suit.keys():
-            return self._possible_discards.remove_random_tile()
+            try:
+                return self._possible_discards.remove_random_tile()
+            except:
+                self._possible_discards.print()
+                self.all_tiles().print()
+                raise ValueError("Random discard failed")
         else:
             tile = tiles_by_suit[self.unwanted_suit].remove_random_tile()
             self._possible_discards.remove(tile)

--- a/code/v1/players.py
+++ b/code/v1/players.py
@@ -1,21 +1,28 @@
 from abc import ABC, abstractmethod
 import random
-from tiles import *
-from mcts import MonteCarloTreeSearchNode
+from v1.tiles import *
+from v1.mcts import MonteCarloTreeSearchNode
 
 
 class Player(ABC):
-    def __init__(self, possible_discards, displayed_tiles=TileList([])):
+    def __init__(
+        self, possible_discards, displayed_tiles=TileList([]), unwanted_suit=None
+    ):
         self._displayed_tiles = displayed_tiles
         self._possible_discards = possible_discards
-        
-        tiles_by_suit = self.possible_discards.get_tiles_by_suit()
-        unwanted = list(tiles_by_suit.keys())[0]
-        for suit in tiles_by_suit.keys():
-            if tiles_by_suit[suit].size() < tiles_by_suit[unwanted].size():
-                unwanted = suit
 
-        self.unwanted_suit = unwanted
+        if unwanted_suit is None:
+
+            tiles_by_suit = self.possible_discards.get_tiles_by_suit()
+            unwanted = list(tiles_by_suit.keys())[0]
+            for suit in tiles_by_suit.keys():
+                if tiles_by_suit[suit].size() < tiles_by_suit[unwanted].size():
+                    unwanted = suit
+                elif tiles_by_suit[suit].size() == tiles_by_suit[unwanted].size():
+                    unwanted = random.choice([suit, unwanted])
+            self.unwanted_suit = unwanted
+        else:
+            self.unwanted_suit = unwanted_suit
 
     @property
     def displayed_tiles(self):
@@ -65,10 +72,12 @@ class Player(ABC):
 
     def discard(self, game_state=None):
         tiles_by_suit = self.possible_discards.get_tiles_by_suit()
-        if self.unwanted_suit not in tiles_by_suit.keys():
+        if tiles_by_suit[self.unwanted_suit].size() == 0:
             try:
                 return self._possible_discards.remove_random_tile()
             except:
+                print(self.unwanted_suit)
+                self._displayed_tiles.print()
                 self._possible_discards.print()
                 self.all_tiles().print()
                 raise ValueError("Random discard failed")
@@ -92,8 +101,10 @@ class RandomAgent(Player):
 
 
 class SemiRandomAgent(Player):
-    def __init__(self, possible_discards, displayed_tiles=TileList([])):
-        super().__init__(possible_discards, displayed_tiles)
+    def __init__(
+        self, possible_discards, displayed_tiles=TileList([]), unwanted_suit=None
+    ):
+        super().__init__(possible_discards, displayed_tiles, unwanted_suit)
         self._pair = TileList([])
         self._locked_tiles = TileList([])
 
@@ -145,7 +156,9 @@ class SemiRandomAgent(Player):
                     and self.possible_discards.contains(second)
                     and self.possible_discards.contains(third)
                 ):
-                    self._possible_discards.remove_tiles(TileList([tile, second, third]))
+                    self._possible_discards.remove_tiles(
+                        TileList([tile, second, third])
+                    )
                     self._locked_tiles.add_tiles(TileList([tile, second, third]))
 
     def lock_triples(self):
@@ -176,14 +189,16 @@ class MCTSAgent(Player):
     def discard(self, game_state):
 
         tiles_by_suit = self.possible_discards.get_tiles_by_suit()
-        if self.unwanted_suit in tiles_by_suit.keys():
+        if tiles_by_suit[self.unwanted_suit].size() > 0:
             tile = tiles_by_suit[self.unwanted_suit].remove_random_tile()
             self._possible_discards.remove(tile)
             return tile
         else:
             # create state for mcts
             # print("initialised with current player: ", game_state._current_player_number)
-            root = MonteCarloTreeSearchNode(game_state.initialise_mcts_state(), self.simulations_to_run)
+            root = MonteCarloTreeSearchNode(
+                game_state.initialise_mcts_state(), self.simulations_to_run
+            )
             selected_node = root.best_action()
 
             if selected_node == -1:

--- a/code/v1/tiles.py
+++ b/code/v1/tiles.py
@@ -4,6 +4,7 @@ from collections import Counter
 from abc import ABC, abstractmethod
 
 
+
 # Tile class definition
 class Tile:
     def __init__(self, suit_type, value):
@@ -193,3 +194,41 @@ class TileList:
             return False
 
         return bt(counts, False)
+    
+    def hand_score(self):
+        # check suit count
+        if len(self.get_tiles_by_suit().keys()) > 2:
+            return 0
+
+        counts = self.tile_counts()
+        triples = len([
+            Tile(tile_str[:-1], tile_str[-1])
+            for tile_str in counts.keys()
+            if counts[tile_str] >= 3
+        ])
+
+        pairs = len([
+            Tile(tile_str[:-1], tile_str[-1])
+            for tile_str in counts.keys()
+            if counts[tile_str] == 2 or counts[tile_str] == 4
+        ])
+
+        self.sort()
+        seq = 0
+        for tile in self.tiles:
+            second = Tile(tile.suit_type, str(int(tile.value) + 1))
+            third = Tile(tile.suit_type, str(int(tile.value) + 2))
+            if (
+                self.contains(tile)
+                and self.contains(second)
+                and self.contains(third)
+            ):
+                seq += 1
+        
+        # 10 is arbitrary
+        score = (pairs + triples + seq) / 20
+
+        if score > 1:
+            raise ValueError("Invalid score:", score)
+
+        return score

--- a/code/v1/tiles.py
+++ b/code/v1/tiles.py
@@ -4,7 +4,6 @@ from collections import Counter
 from abc import ABC, abstractmethod
 
 
-
 # Tile class definition
 class Tile:
     def __init__(self, suit_type, value):
@@ -48,16 +47,16 @@ class TileList:
         self.sort()
         other.sort()
         return self.tiles == other.tiles
-    
-    def get_tiles_by_suit(self):
-        tiles_by_suit = {}
-        for t in self.tiles:
-            if t.suit_type not in tiles_by_suit.keys():
-                tiles_by_suit[t.suit_type] = TileList([t])
-            else:
-                tiles_by_suit[t.suit_type].add(t)
-        return tiles_by_suit
 
+    def get_tiles_by_suit(self):
+        tiles_by_suit = {
+            "Bamboo": TileList([]),
+            "Numbers": TileList([]),
+            "Circles": TileList([]),
+        }
+        for t in self.tiles:
+            tiles_by_suit[t.suit_type].add(t)
+        return tiles_by_suit
 
     def print_form(self):
         to_print = []
@@ -194,39 +193,42 @@ class TileList:
             return False
 
         return bt(counts, False)
-    
-    def hand_score(self):
+
+    def hand_score(self, unwanted_suit):
         # check suit count
-        if len(self.get_tiles_by_suit().keys()) > 2:
+        if self.get_tiles_by_suit()[unwanted_suit].size() > 0:
             return 0
 
         counts = self.tile_counts()
-        triples = len([
-            Tile(tile_str[:-1], tile_str[-1])
-            for tile_str in counts.keys()
-            if counts[tile_str] >= 3
-        ])
+        triples = len(
+            [
+                Tile(tile_str[:-1], tile_str[-1])
+                for tile_str in counts.keys()
+                if counts[tile_str] >= 3
+            ]
+        )
 
-        pairs = len([
-            Tile(tile_str[:-1], tile_str[-1])
-            for tile_str in counts.keys()
-            if counts[tile_str] == 2 or counts[tile_str] == 4
-        ])
+        pairs = len(
+            [
+                Tile(tile_str[:-1], tile_str[-1])
+                for tile_str in counts.keys()
+                if counts[tile_str] == 2 or counts[tile_str] == 4
+            ]
+        )
 
         self.sort()
         seq = 0
         for tile in self.tiles:
             second = Tile(tile.suit_type, str(int(tile.value) + 1))
             third = Tile(tile.suit_type, str(int(tile.value) + 2))
-            if (
-                self.contains(tile)
-                and self.contains(second)
-                and self.contains(third)
-            ):
+            if self.contains(tile) and self.contains(second) and self.contains(third):
                 seq += 1
-        
+
         # 10 is arbitrary
         score = (pairs + triples + seq) / 20
+
+        # self.print()
+        # print(score)
 
         if score > 1:
             raise ValueError("Invalid score:", score)


### PR DESCRIPTION
Unwanted suit resulted in bug - each time the mcts was running it was reassigning the unwanted suit of each player - this is fixed by making it a player attribute. However there are games that still fail and it is unknown why - can't pick randrange(0, 0) and sometimes players end up with 16 tiles (likely the result of a PENG adding tiles to the hand of the wrong player). Hand scoring implemented for the purpose of improving mcts where it checks the number of sets of 3 and pairs the agent holds as the win rate is too low. 